### PR TITLE
Add second 1wallet address for metrics

### DIFF
--- a/src/store/postgres/OneWalletMetrics.ts
+++ b/src/store/postgres/OneWalletMetrics.ts
@@ -1,7 +1,10 @@
 import {Query} from 'src/store/postgres/types'
 import {Address} from 'src/types'
 
-const OneWalletAddress = '0xc8cd0c9ca68b853f73917c36e9276770a8d8e4e0'
+const oneWalletAddresses = [
+  '0xc8cd0c9ca68b853f73917c36e9276770a8d8e4e0',
+  '0xe0f4dda31750e410a7cc62f7aa5ae95fa56f050d',
+].map((a) => a.toLowerCase())
 
 export class PostgresStorageOneWalletMetrics {
   query: Query
@@ -12,8 +15,11 @@ export class PostgresStorageOneWalletMetrics {
 
   getWallets = async (): Promise<Address[]> => {
     const res = await this.query(
-      `select "to" from internal_transactions where "from"=$1 and type='create'`,
-      [OneWalletAddress]
+      `
+            select "to" from internal_transactions
+            where "from" = any ($1) and type='create'
+      `,
+      [oneWalletAddresses]
     )
 
     // @ts-ignore


### PR DESCRIPTION
Add support of two 1wallet addresses for /v0/1wallet/metrics endpoint:
- 0xc8cd0c9ca68b853f73917c36e9276770a8d8e4e0 existed
- 0xe0f4dda31750e410a7cc62f7aa5ae95fa56f050d new one