### PR TITLE
Feature/eth get logs

### DIFF
--- a/src/api/controllers/log.ts
+++ b/src/api/controllers/log.ts
@@ -15,6 +15,7 @@ import {
   isAddress,
 } from 'src/utils/validators'
 import {
+  EthGetLogParams,
   Filter,
   InternalTransactionQueryField,
   TransactionQueryField,
@@ -84,4 +85,8 @@ export async function getDetailedLogsByField(
   return await withCache(['getDetailedLogsByField', arguments], () =>
     stores[shardID].log.getDetailedLogsByField(field, value, limit, offset)
   )
+}
+
+export async function ethGetLogs(shardID: ShardID, params: EthGetLogParams): Promise<any> {
+  return stores[shardID].log.ethGetLogs(params)
 }

--- a/src/api/rest/routes/rpcRouter.ts
+++ b/src/api/rest/routes/rpcRouter.ts
@@ -1,0 +1,58 @@
+import {Response, Request, Router, NextFunction} from 'express'
+import * as controllers from 'src/api/controllers'
+import {catchAsync} from 'src/api/rest/utils'
+import {EthGetLogParams} from 'src/types'
+
+export const rpcRouter = Router({mergeParams: true})
+
+enum RPCMethod {
+  ethGetLogs = 'eth_getLogs',
+}
+
+enum RPCErrorCode {
+  unknownMethod = -32601,
+  paramsNotDefined = -32700,
+}
+
+rpcRouter.post('/', catchAsync(postRpcRequest))
+
+const wrapRpcResponse = (key: string, value: any) => {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    [key]: value,
+  }
+}
+
+export async function postRpcRequest(req: Request, res: Response, next: NextFunction) {
+  const {method, params} = req.body
+
+  if (!params || !Array.isArray(params)) {
+    return res.send(
+      wrapRpcResponse('error', {
+        code: RPCErrorCode.paramsNotDefined,
+        message: `missing value for required argument 0`,
+      })
+    )
+  }
+
+  switch (method) {
+    case RPCMethod.ethGetLogs: {
+      const data = await ethGetLogs(params[0])
+      res.send(wrapRpcResponse('result', data))
+      break
+    }
+    default: {
+      res.send(
+        wrapRpcResponse('error', {
+          code: RPCErrorCode.unknownMethod,
+          message: `the method ${method} does not exist/is not available`,
+        })
+      )
+    }
+  }
+}
+
+function ethGetLogs(params: EthGetLogParams) {
+  return controllers.ethGetLogs(0, params)
+}

--- a/src/api/rest/routes/rpcRouter.ts
+++ b/src/api/rest/routes/rpcRouter.ts
@@ -7,6 +7,7 @@ export const rpcRouter = Router({mergeParams: true})
 
 enum RPCMethod {
   ethGetLogs = 'eth_getLogs',
+  hmyGetLogs = 'hmy_getLogs',
 }
 
 enum RPCErrorCode {
@@ -36,23 +37,34 @@ export async function postRpcRequest(req: Request, res: Response, next: NextFunc
     )
   }
 
-  switch (method) {
-    case RPCMethod.ethGetLogs: {
-      const data = await ethGetLogs(params[0])
-      res.send(wrapRpcResponse('result', data))
-      break
+  try {
+    switch (method) {
+      case RPCMethod.ethGetLogs:
+      case RPCMethod.hmyGetLogs: {
+        const data = await ethGetLogs(params[0])
+        res.send(wrapRpcResponse('result', data))
+        break
+      }
+      default: {
+        res.send(
+          wrapRpcResponse('error', {
+            code: RPCErrorCode.unknownMethod,
+            message: `the method ${method} does not exist/is not available`,
+          })
+        )
+      }
     }
-    default: {
-      res.send(
-        wrapRpcResponse('error', {
-          code: RPCErrorCode.unknownMethod,
-          message: `the method ${method} does not exist/is not available`,
-        })
-      )
-    }
+  } catch (e) {
+    res.send(wrapRpcResponse('error', {message: e.message || 'Unknown error'}))
   }
 }
 
 function ethGetLogs(params: EthGetLogParams) {
+  if (params.fromBlock) {
+    params.fromBlock = params.fromBlock.toLowerCase()
+  }
+  if (params.toBlock) {
+    params.toBlock = params.toBlock.toLowerCase()
+  }
   return controllers.ethGetLogs(0, params)
 }

--- a/src/api/rest/server.ts
+++ b/src/api/rest/server.ts
@@ -51,7 +51,7 @@ export const RESTServer = async () => {
   routerWithShards0.use('/erc721', erc721Router, transport)
   routerWithShards0.use('/erc1155', erc1155Router, transport)
   routerWithShards0.use('/1wallet', oneWalletMetricsRouter, transport)
-  routerWithShards0.use('/', rpcRouter, transport)
+  routerWithShards0.use('/rpc', rpcRouter, transport)
 
   api.use('/v0', routerWithShards0)
 

--- a/src/api/rest/server.ts
+++ b/src/api/rest/server.ts
@@ -18,6 +18,7 @@ import {erc721Router} from 'src/api/rest/routes/ERC721'
 import {erc1155Router} from 'src/api/rest/routes/ERC1155'
 import {oneWalletMetricsRouter} from 'src/api/rest/routes/oneWalletMetrics'
 import {warmUpCache} from 'src/api/controllers/cache/warmUpCache'
+import {rpcRouter} from 'src/api/rest/routes/rpcRouter'
 
 import {transport} from 'src/api/rest/transport'
 const l = logger(module)
@@ -50,6 +51,7 @@ export const RESTServer = async () => {
   routerWithShards0.use('/erc721', erc721Router, transport)
   routerWithShards0.use('/erc1155', erc1155Router, transport)
   routerWithShards0.use('/1wallet', oneWalletMetricsRouter, transport)
+  routerWithShards0.use('/', rpcRouter, transport)
 
   api.use('/v0', routerWithShards0)
 

--- a/src/store/postgres/Log.ts
+++ b/src/store/postgres/Log.ts
@@ -107,9 +107,14 @@ export class PostgresStorageLog implements IStorageLog {
     const whereClause = []
 
     if (blockhash) {
-      whereClause.push('block_number = :blockhash')
+      whereClause.push('block_hash = :blockhash')
     } else {
-      whereClause.push('block_number >= :fromBlockInteger and block_number <= :toBlockInteger')
+      if (fromBlock) {
+        whereClause.push('block_number >= :fromBlockInteger')
+      }
+      if (toBlock) {
+        whereClause.push('block_number <= :toBlockInteger')
+      }
     }
 
     if (address) {
@@ -141,7 +146,7 @@ export class PostgresStorageLog implements IStorageLog {
       `
         select * from logs
         where ${whereClause.length > 0 ? whereClause.join(' and ') : ''}
-        order by block_number desc, log_index asc
+        limit 1000
     `,
       filteredParams
     )

--- a/src/store/postgres/queryMapper.ts
+++ b/src/store/postgres/queryMapper.ts
@@ -1,3 +1,5 @@
+import {Log} from 'src/types'
+
 export const mapNaming: Record<string, string> = {
   extra_data: 'extraData',
   gas_limit: 'gasLimit',
@@ -85,4 +87,26 @@ export const generateQuery = (o: Record<any, any>) => {
     query,
     params,
   }
+}
+
+const intToHex = (value: string | number) => '0x' + (+value).toString(16)
+
+export const mapLogToEthLog = (log: Log) => {
+  return {
+    ...log,
+    blockNumber: intToHex(log.blockNumber),
+    transactionIndex: intToHex(log.transactionIndex),
+    logIndex: intToHex(log.logIndex),
+  }
+}
+
+type QueryReducerArray = [string, any[], number]
+
+export function queryParamsConvert(parameterizedSql: string, params: Record<string, any>) {
+  const [text, values] = Object.entries(params).reduce(
+    ([sql, array, index], [key, value]) =>
+      [sql.replace(`:${key}`, `$${index}`), [...array, value], index + 1] as QueryReducerArray,
+    [parameterizedSql, [], 1] as QueryReducerArray
+  )
+  return {text, values}
 }

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -51,6 +51,7 @@ create index if not exists idx_logs_block_hash on logs using hash (block_hash);
 create index if not exists idx_logs_block_number on logs (block_number desc);
 create index if not exists idx_logs_block_number_asc on logs (block_number);
 create index if not exists idx_logs_block_number_address on logs (block_number desc, address);
+create index if not exists idx_gin_logs_topics on logs using GIN (topics);
 
 create table if not exists transactions
 (

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -49,3 +49,11 @@ export type Filter = {
   orderBy?: FilterOrderBy
   filters: FilterEntry[]
 }
+
+export interface EthGetLogParams {
+  fromBlock: string
+  toBlock: string
+  address?: string | string[]
+  topics?: string[]
+  blockhash?: string
+}


### PR DESCRIPTION
Add eth_getLogs (or hmy_getLogs) endpoint to explorer backend api.
Available on POST <explorer_api>/v0/rpc with payload described in docs:
[docs api](https://docs.harmony.one/home/developers/api/methods/filter-methods/hmy_getlogs)

example payload:
```

{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_getLogs",
    "params": [{
        "address": "0x72cb10c6bfa5624dd07ef608027e366bd690048f",
        "topics": ["0x625fed9875dada8643f2418b838ae0bc78d9a148a18eee4ee1979ff0f3f5d427", "0x00000000000000000000000079f0d0670d17a89f509ad1c16bb6021187964a29"]
    }]
}
```