### PR TITLE
Allow single quote in sql values

### DIFF
--- a/src/store/postgres/filters/index.ts
+++ b/src/store/postgres/filters/index.ts
@@ -17,7 +17,10 @@ const propertyToString = (property: string) => {
 export const buildSQLQuery = (query: Filter) => {
   const safeSQL = (value: any) => {
     // todo safe trim value
-    return (value + '').split(' ').join('').replace(/[^a-zA-Z0-9 _-]/g, '')
+    return (value + '')
+      .split(' ')
+      .join('')
+      .replace(/[^a-zA-Z0-9 \\'_-]/g, '')
   }
 
   const whereQuery = query.filters


### PR DESCRIPTION
Fixed clearing sql query params

For example, buildSQLQuery params:
```

{
  limit: 10000,
  offset: 0,
  orderDirection: 'asc',
  orderBy: 'block_number',
  filters: [
    { type: 'gt', property: 'block_number', value: 22247226 },
    {
      value: "'0xaca590e04b1faa2dbdc499f831baf99f5cda57d0'",
      type: 'eq',
      property: 'address'
    }
  ]
}
```

producing wrong query without single quote

`select * from logs where block_number > 22238970 and address = 0xaca590e04b1faa2dbdc499f831baf99f5cda57d0 order by block_number asc  limit 10000`
