### PR TITLE
Add has_internal_values to transactions

### DIFF
--- a/src/indexer/indexer/BlockIndexer.ts
+++ b/src/indexer/indexer/BlockIndexer.ts
@@ -1,6 +1,12 @@
 import * as RPCClient from 'src/indexer/rpc/client'
 import {urls, RPCUrls} from 'src/indexer/rpc/RPCUrls'
-import {ShardID, Block, BlockNumber, InternalTransaction} from 'src/types/blockchain'
+import {
+  ShardID,
+  Block,
+  BlockNumber,
+  InternalTransaction,
+  TransactionExtraMark,
+} from 'src/types/blockchain'
 import {arrayChunk, defaultChunkSize} from 'src/utils/arrayChunk'
 import {logger} from 'src/logger'
 import LoggerModule from 'zerg/dist/LoggerModule'
@@ -149,13 +155,15 @@ export class BlockIndexer {
             const blockTxs = block.transactions.map((tx) => {
               // todo handle empty create to addresses
               addressIndexer.add(block, tx.ethHash, 'transaction', tx.from, tx.to)
-              const hasInternalValues = !!internalTxs.find(
+              const extraMark = internalTxs.find(
                 (internalTx) =>
                   internalTx.transactionHash === tx.ethHash && BigInt(internalTx.value) > 0
               )
+                ? TransactionExtraMark.hasInternalONETransfers
+                : TransactionExtraMark.normal
               return {
                 ...tx,
-                hasInternalValues,
+                extraMark,
               }
             })
 

--- a/src/store/postgres/queryMapper.ts
+++ b/src/store/postgres/queryMapper.ts
@@ -38,7 +38,7 @@ export const mapNaming: Record<string, string> = {
   ipfs_hash: 'IPFSHash',
   last_update_block_number: 'lastUpdateBlockNumber',
   token_uri: 'tokenURI',
-  has_internal_values: 'hasInternalValues',
+  extra_mark: 'extraMark',
 }
 
 export const mapNamingReverse: Record<string, string> = Object.keys(mapNaming).reduce((a, k) => {

--- a/src/store/postgres/queryMapper.ts
+++ b/src/store/postgres/queryMapper.ts
@@ -38,6 +38,7 @@ export const mapNaming: Record<string, string> = {
   ipfs_hash: 'IPFSHash',
   last_update_block_number: 'lastUpdateBlockNumber',
   token_uri: 'tokenURI',
+  has_internal_values: 'hasInternalValues',
 }
 
 export const mapNamingReverse: Record<string, string> = Object.keys(mapNaming).reduce((a, k) => {

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -87,7 +87,7 @@ create table if not exists transactions
     v                 text,
     success           boolean,
     error             text,
-    extra_mark        transaction_extra_mark            default 'normal',
+    extra_mark        transaction_extra_mark            default 'normal'
 );
 create index if not exists idx_transactions_hash on transactions using hash (hash);
 create index if not exists idx_transactions_hash_harmony on transactions using hash (hash_harmony);

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -53,6 +53,18 @@ create index if not exists idx_logs_block_number_asc on logs (block_number);
 create index if not exists idx_logs_block_number_address on logs (block_number desc, address);
 create index if not exists idx_gin_logs_topics on logs using GIN (topics);
 
+do
+$$
+    begin
+        create type transaction_extra_mark as enum (
+            'normal',
+            'hasInternalONETransfers'
+        );
+    exception
+        when duplicate_object then null;
+    end
+$$;
+
 create table if not exists transactions
 (
     shard             smallint                          not null,
@@ -75,7 +87,7 @@ create table if not exists transactions
     v                 text,
     success           boolean,
     error             text,
-    has_internal_values boolean
+    extra_mark        transaction_extra_mark            default 'normal',
 );
 create index if not exists idx_transactions_hash on transactions using hash (hash);
 create index if not exists idx_transactions_hash_harmony on transactions using hash (hash_harmony);

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -74,7 +74,8 @@ create table if not exists transactions
     transaction_index smallint,
     v                 text,
     success           boolean,
-    error             text
+    error             text,
+    has_internal_values boolean
 );
 create index if not exists idx_transactions_hash on transactions using hash (hash);
 create index if not exists idx_transactions_hash_harmony on transactions using hash (hash_harmony);

--- a/src/types/blockchain.ts
+++ b/src/types/blockchain.ts
@@ -122,6 +122,11 @@ export type TransactionReceipt = RPCTransaction & {
   ]
 }
 
+export enum TransactionExtraMark {
+  normal = 'normal',
+  hasInternalONETransfers = 'hasInternalONETransfers',
+}
+
 export type RPCTransactionHarmony = {
   blockHash: BlockHash
   blockNumber: BlockHexNumber
@@ -141,7 +146,7 @@ export type RPCTransactionHarmony = {
   transactionIndex: string
   v: string
   value: string
-  hasInternalValues: boolean
+  extraMark: TransactionExtraMark
 }
 export type StakingTransactionType =
   | 'CreateValidator'

--- a/src/types/blockchain.ts
+++ b/src/types/blockchain.ts
@@ -141,6 +141,7 @@ export type RPCTransactionHarmony = {
   transactionIndex: string
   v: string
   value: string
+  hasInternalValues: boolean
 }
 export type StakingTransactionType =
   | 'CreateValidator'


### PR DESCRIPTION
1) Added enum
```
create type transaction_extra_mark as enum (
            'normal',
            'hasInternalONETransfers'
);
```
and `extra_mark` column to `transactions` table. Default value `normal`
2) If tx contains internal with positive value, extra_mark will be set to `hasInternalONETransfers`
3) Changed order of actions in Blocks indexer: 
- get blocks
- get blocks trace BEFORE writing internal and transactions because `internal_transactions` related to `transactions` table
- use internal txs to set `hasInternalONETransfers` mark for txs, write transactions
- write internal transactions