### PR TITLE
Add block_number filter to internal_transactions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ export const config = {
     isEnabled: toBool(process.env.API_IS_ENABLED || '0'),
     isCacheEnabled: toBool(process.env.API_IS_CACHE_ENABLED || '0'),
     cacheMaxSize: +(process.env.API_CACHE_MAX_SIZE || 1000 * 100),
+    internalTxsBlockNumberStart: +(process.env.INTERNAL_TXS_BLOCK_NUMBER_START || 23000000),
     ws: {
       isEnabled: toBool(process.env.API_WS_IS_ENABLED || '0'),
       port: 3001,


### PR DESCRIPTION
1) Added env variable INTERNAL_TXS_BLOCK_NUMBER_START, default = 23000000
Production table is not indexed with block numbers less that 23M
2) Filter internal_transactions history starting from block INTERNAL_TXS_BLOCK_NUMBER_START