### PR TITLE
Refactor 1Wallet metrics

### DIFF
--- a/mainnet.env.example
+++ b/mainnet.env.example
@@ -21,6 +21,8 @@ INDEXER_LOG_INITIAL_BLOCK_SYNCING_HEIGHT=10010121
 INDEXER_CONTRACTS_IS_ENABLED=1
 # smart contract trackers erc20,erc721 comma separated
 INDEXER_CONTRACTS_TYPES=erc20,erc721
+# onewallet total balances indexer, running once a day
+INDEXER_ONEWALLET_IS_ENABLED=1
 
 # shard ids synced by indexer comma separated 0,1,2,3
 INDEXER_SHARDS=0

--- a/src/api/controllers/oneWalletMetrics.ts
+++ b/src/api/controllers/oneWalletMetrics.ts
@@ -4,18 +4,10 @@ import {withCache} from 'src/api/controllers/cache'
 import nodeFetch from 'node-fetch'
 
 export async function oneWalletGetMetrics(): Promise<any> {
-  const addressList = await withCache(
-    ['oneWalletGetMetrics'],
-    () => stores[0].oneWalletMetrics.getWallets(),
-    1000 * 60 * 60 * 23,
-    false
-  )
-
-  const count = addressList.length
-  const totalAmount = await withCache(
+  const {count, totalAmount} = await withCache(
     ['oneWalletGetBalances'],
-    () => getTotalAmount(addressList),
-    1000 * 60 * 60 * 23,
+    () => stores[0].oneWalletMetrics.getMetrics(),
+    1000 * 60 * 60,
     false
   )
 
@@ -23,39 +15,4 @@ export async function oneWalletGetMetrics(): Promise<any> {
     count,
     totalAmount,
   }
-}
-
-const RPCURL = 'https://api.s0.t.hmny.io'
-const getTotalAmount = async (addressList: Address[]) => {
-  const fetchBalance = async (address: Address, retries = 5): Promise<string> => {
-    const body = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'hmy_getBalance',
-      params: [address, 'latest'],
-    }
-
-    const payload = {
-      method: 'post',
-      body: JSON.stringify(body),
-      headers: {'Content-Type': 'application/json'},
-    }
-
-    return nodeFetch(RPCURL, payload)
-      .then((r) => r.json())
-      .then((r) => r.result)
-      .catch(async (err) => {
-        if (retries > 0) {
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-          return fetchBalance(address, retries - 1)
-        }
-
-        throw new Error(err)
-      })
-  }
-
-  const balances = await Promise.all(addressList.map(fetchBalance))
-  const totalAmount = balances.reduce((a, b) => (a += BigInt(b)), BigInt(0))
-
-  return totalAmount.toString()
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,7 @@ export const config = {
     isSyncingBlocksEnabled: toBool(process.env.INDEXER_BLOCKS_IS_ENABLED || '0'),
     isSyncingLogsEnabled: toBool(process.env.INDEXER_LOGS_IS_ENABLED || '0'),
     isSyncingContractsEnabled: toBool(process.env.INDEXER_CONTRACTS_IS_ENABLED || '0'),
+    isSyncingOneWalletEnabled: toBool(process.env.INDEXER_ONEWALLET_IS_ENABLED || '0'),
     trackContractTypes: getCommaSeparatedList(process.env.INDEXER_CONTRACTS_TYPES),
     initialBlockSyncingHeight: +(process.env.INDEXER_INITIAL_BLOCK_SYNCING_HEIGHT || 0),
     // set to the height where smart contracts were introduced on the chain

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -11,6 +11,7 @@ import * as RPCClient from 'src/indexer/rpc/client'
 import {urls, RPCUrls} from 'src/indexer/rpc/RPCUrls'
 
 import {walletCountIndexer} from 'src/indexer/indexer/metrics/walletCount'
+import {oneWalletIndexer} from 'src/indexer/indexer/metrics/oneWallet'
 
 const l = logger(module)
 
@@ -38,6 +39,10 @@ export const indexer = async () => {
   // todo enabled flag config for the task
   if (config.indexer.shards.includes(0)) {
     walletCountIndexer()
+  }
+
+  if (config.indexer.isSyncingOneWalletEnabled && config.indexer.shards.includes(0)) {
+    oneWalletIndexer()
   }
 
   if (config.indexer.isSyncingLogsEnabled && config.indexer.shards.includes(0)) {

--- a/src/indexer/indexer/metrics/oneWallet.ts
+++ b/src/indexer/indexer/metrics/oneWallet.ts
@@ -1,0 +1,88 @@
+import {logger} from 'src/logger'
+import {stores} from 'src/store'
+import {Address} from 'src/types'
+import nodeFetch from 'node-fetch'
+
+const l = logger(module)
+const interval = 1000 * 60 * 60
+
+const RPCURL = 'https://api.s0.t.hmny.io'
+
+export const oneWalletIndexer = () => {
+  l.info('One wallet balances indexer starting...')
+  loop()
+}
+
+const fetchAddressBalance = async (address: Address, retries = 5): Promise<string> => {
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'hmy_getBalance',
+    params: [address, 'latest'],
+  }
+
+  const payload = {
+    method: 'post',
+    body: JSON.stringify(body),
+    headers: {'Content-Type': 'application/json'},
+  }
+
+  return nodeFetch(RPCURL, payload)
+    .then((r) => r.json())
+    .then((r) => r.result)
+    .catch(async (err) => {
+      if (retries > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        return fetchAddressBalance(address, retries - 1)
+      }
+      throw new Error(err)
+    })
+}
+
+const getTotalAmount = async (addressList: Address[]): Promise<BigInt> => {
+  const balances = await Promise.all(addressList.map(fetchAddressBalance))
+  return balances.reduce((a, b) => (a += BigInt(b)), BigInt(0))
+}
+
+const sleep = (timeout: number) => new Promise((resolve) => setTimeout(resolve, timeout))
+
+const updateBalances = async () => {
+  try {
+    const store = stores[0].oneWalletMetrics
+    const lastUpdateDaysDiff = await store.getMetricsLastUpdateDiff()
+    l.info(
+      `Previous update days diff: ${lastUpdateDaysDiff}${
+        lastUpdateDaysDiff === 0 ? ', skip until next day' : ''
+      }`
+    )
+    if (lastUpdateDaysDiff > 0) {
+      const addressesCount = await store.getAddressesToUpdateCount()
+      if (addressesCount > 0) {
+        l.info(`Starting update oneWallet addresses balance, total count: "${addressesCount}"`)
+        let totalBalance = BigInt(0)
+        const chunkSize = 1000 // Number of address balances to be requested in single batch
+        const timeStart = Date.now()
+        for (let i = 0; i < addressesCount; i += chunkSize) {
+          const addresses = await store.getAddressesToUpdate(i, chunkSize)
+          const balance = await getTotalAmount(addresses)
+          // @ts-ignore
+          totalBalance += balance
+          await sleep(1000)
+        }
+        await store.addMetrics(addressesCount, totalBalance.toString())
+        l.info(
+          `Updated oneWallet addresses count = "${addressesCount}"` +
+            `, total balance = "${totalBalance}"` +
+            `, elapsed time ${Math.round((Date.now() - timeStart) / 1000)}s`
+        )
+      }
+    }
+  } catch (e) {
+    l.error('One wallet metrics update error:', e.message || e)
+  }
+}
+
+const loop = async () => {
+  await updateBalances()
+  setTimeout(loop, interval)
+}

--- a/src/indexer/indexer/metrics/walletCount.ts
+++ b/src/indexer/indexer/metrics/walletCount.ts
@@ -5,8 +5,8 @@ const l = logger(module)
 const interval = 1000 * 60 * 60 * 12
 
 export const walletCountIndexer = () => {
-  l.info('Wallet counter starting...')
-  l.warn('Heavy task, make sure you need it enabled')
+  // l.info('Wallet counter starting...')
+  // l.warn('Heavy task, make sure you need it enabled')
   // loop()
 }
 

--- a/src/store/postgres/OneWalletMetrics.ts
+++ b/src/store/postgres/OneWalletMetrics.ts
@@ -37,12 +37,7 @@ export class PostgresStorageOneWalletMetrics {
   }
 
   getAddressesToUpdateCount = async () => {
-    const res = await this.query(
-      `
-      select count(*) from onewallet_owners
-    `,
-      []
-    )
+    const res = await this.query(`select count(*) from onewallet_owners`, [])
     return res[0].count
   }
 
@@ -50,9 +45,8 @@ export class PostgresStorageOneWalletMetrics {
     const res = await this.query(
       `
       SELECT extract(day from current_date - created_at) AS days
-      from onewallet_metrics om 
-      order by id desc 
-      offset 0
+      from onewallet_metrics
+      order by id desc
       limit 1
     `,
       []

--- a/src/store/postgres/OneWalletMetrics.ts
+++ b/src/store/postgres/OneWalletMetrics.ts
@@ -13,16 +13,100 @@ export class PostgresStorageOneWalletMetrics {
     this.query = query
   }
 
-  getWallets = async (): Promise<Address[]> => {
+  addOwner = (address: string, txHash: string, blockNumber: number) => {
+    return this.query(
+      `
+            insert into onewallet_owners (address, transaction_hash, block_number) values($1, $2, $3)
+            on conflict (address) do nothing;
+      `,
+      [address, txHash, blockNumber]
+    )
+  }
+
+  updateBalance = (address: string, balance: number) => {
+    return this.query(
+      `
+            update onewallet_owners
+            set balance = $2
+            where address = $1;
+      `,
+      [address, balance]
+    )
+  }
+
+  markBalanceIsUpdated = (address: string, isBalanceUpdated = false) => {
+    return this.query(
+      `
+            update onewallet_owners
+            set is_balance_updated = $2
+            where address = $1;
+      `,
+      [address, isBalanceUpdated]
+    )
+  }
+
+  getAddressesToUpdate = async (offset = 0, limit = 100000) => {
+    const res: Array<{address: string}> = await this.query(
+      `
+      select * from onewallet_owners
+      order by block_number desc
+      offset $1
+      limit $2
+    `,
+      [offset, limit]
+    )
+    return res.map((item) => item.address)
+  }
+
+  getAddressesToUpdateCount = async () => {
     const res = await this.query(
       `
-            select "to" from internal_transactions
-            where "from" = any ($1) and type='create'
+      select count(*) from onewallet_owners
+    `,
+      []
+    )
+    return res[0].count
+  }
+
+  getMetricsLastUpdateDiff = async (): Promise<number> => {
+    const res = await this.query(
+      `
+      SELECT extract(day from current_date - created_at) AS days
+      from onewallet_metrics om 
+      order by id desc 
+      offset 0
+      limit 1
+    `,
+      []
+    )
+    return res.length > 0 ? +res[0].days : Infinity
+  }
+
+  addMetrics = (count: string, totalBalance: string) => {
+    return this.query(
+      `
+      insert into onewallet_metrics (owners_count, total_balance)
+      values ($1, $2)
+      on conflict (created_at) do nothing;
+    `,
+      [count, totalBalance]
+    )
+  }
+
+  getMetrics = async (): Promise<{count: string; totalAmount: string}> => {
+    const res = await this.query(
+      `
+            select owners_count as count, total_balance as balance
+            from onewallet_metrics
+            order by id desc
+            limit 1
       `,
-      [oneWalletAddresses]
+      []
     )
 
-    // @ts-ignore
-    return res.map((r) => r.to)
+    return {
+      count: res.length ? res[0].count : '0',
+      totalAmount: res.length ? res[0].balance : '0',
+    }
   }
 }

--- a/src/store/postgres/OneWalletMetrics.ts
+++ b/src/store/postgres/OneWalletMetrics.ts
@@ -23,28 +23,6 @@ export class PostgresStorageOneWalletMetrics {
     )
   }
 
-  updateBalance = (address: string, balance: number) => {
-    return this.query(
-      `
-            update onewallet_owners
-            set balance = $2
-            where address = $1;
-      `,
-      [address, balance]
-    )
-  }
-
-  markBalanceIsUpdated = (address: string, isBalanceUpdated = false) => {
-    return this.query(
-      `
-            update onewallet_owners
-            set is_balance_updated = $2
-            where address = $1;
-      `,
-      [address, isBalanceUpdated]
-    )
-  }
-
   getAddressesToUpdate = async (offset = 0, limit = 100000) => {
     const res: Array<{address: string}> = await this.query(
       `

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -429,3 +429,18 @@ create table if not exists contract_events
 create index if not exists idx_contract_events_from_block_number on contract_events ("from", block_number desc);
 create index if not exists idx_contract_events_to_block_number on contract_events ("to", block_number desc);
 create index if not exists idx_contract_events_transaction_hash on contract_events using hash (transaction_hash);
+
+create table if not exists onewallet_owners
+(
+    address             char(42) not null primary key,
+    transaction_hash    char(66) not null,
+    block_number        bigint not null
+);
+
+create table if not exists onewallet_metrics
+(
+    id                  serial primary key,
+    created_at          timestamp unique not null default current_date,
+    owners_count        bigint not null default (0),
+    total_balance       numeric default (0)
+);


### PR DESCRIPTION
1) check for 1wallet `create` when parsing block, write owner address to `onewallet_owners` table
2) once a day update balances and write total balance and owners count to `onewallet_metrics`table
3) read `onewallet_metrics` table last row on user requests to GET /v0/1wallet/metrics

Added new env variable `INDEXER_ONEWALLET_IS_ENABLED`