### PR TITLE
Add rate limiter to all REST endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^8.2.0",
     "ethereum-bloom-filters": "^1.0.9",
     "express": "^4.17.1",
+    "express-rate-limit": "^6.4.0",
     "grpc": "^1.24.6",
     "grpc-reflection-js": "^0.1.1",
     "ipfs-http-client": "^50.1.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,11 @@ export const config = {
       isEnabled: toBool(process.env.API_GRPC_IS_ENABLED || '0'),
       port: 5051,
     },
+    rateLimiter: {
+      isEnabled: toBool(process.env.API_RATE_LIMITER_IS_ENABLED || '1'),
+      windowMs: +(process.env.API_RATE_LIMITER_WINDOW_MS || 10 * 60 * 1000), // 10 minutes
+      max: +(process.env.API_RATE_LIMITER_MAX || 200), // // Limit each IP to 200 requests per `windowMs` = 10 minutes
+    },
   },
   indexer: {
     chainID: getChainID(process.env.CHAIN_ID || 'mainnet'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,6 +3038,11 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+express-rate-limit@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-6.4.0.tgz#b7066afe21157a012ed2b7c9adde386e712485cd"
+  integrity sha512-lxQRZI4gi3qAWTf0/Uqsyugsz57h8bd7QyllXBgJvd6DJKokzW7C5DTaNvwzvAQzwHGFaItybfYGhC8gpu0V2A==
+
 express@^4.14.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.npmjs.org/express/-/express-4.17.1.tgz"


### PR DESCRIPTION
1) Added new env variables
`API_RATE_LIMITER_IS_ENABLED`=1
`API_RATE_LIMITER_WINDOW_MS`=10 * 60 * 1000
`API_RATE_LIMITER_MAX`=200

It means: allow maximum 200 request per IP address per 10 minutes

2) Added REST API rate limiter for all endpoints, enabled by default
To turn off, set API_RATE_LIMITER_IS_ENABLED=0