### PR TITLE
Reduce cache lifetime

### DIFF
--- a/src/api/controllers/ERC1155.ts
+++ b/src/api/controllers/ERC1155.ts
@@ -20,7 +20,7 @@ export async function getUserERC1155Balances(address: Address): Promise<IERC20Ba
   return await withCache(
     ['getUserERC1155Balances', arguments],
     () => stores[0].erc1155.getUserBalances(address),
-    1000 * 60 * 5
+    1000 * 2
   )
 }
 
@@ -32,7 +32,7 @@ export async function getTokenERC1155Balances(address: Address): Promise<IERC20B
   return await withCache(
     ['getTokenERC1155Balances', arguments],
     () => stores[0].erc1155.getTokenBalances(address),
-    1000 * 60 * 5
+    1000 * 10
   )
 }
 

--- a/src/api/controllers/ERC20.ts
+++ b/src/api/controllers/ERC20.ts
@@ -38,6 +38,6 @@ export async function getERC20TokenHolders(
   return await withCache(
     ['getERC20TokenHolders', arguments],
     () => stores[0].erc20.getHolders(address, limit, offset),
-    1000 * 60 * 5
+    1000 * 10
   )
 }

--- a/src/api/controllers/ERC721.ts
+++ b/src/api/controllers/ERC721.ts
@@ -20,7 +20,7 @@ export async function getUserERC721Assets(address: Address): Promise<IERC20Balan
   return await withCache(
     ['getUserERC721Assets', arguments],
     () => stores[0].erc721.getUserAssets(address),
-    1000 * 60 * 5
+    1000 * 2
   )
 }
 
@@ -32,6 +32,6 @@ export async function getTokenERC721Assets(address: Address): Promise<IERC20Bala
   return await withCache(
     ['getTokenERC721Assets', arguments],
     () => stores[0].erc721.getTokenAssets(address),
-    1000 * 60 * 5
+    1000 * 2
   )
 }

--- a/src/api/controllers/address.ts
+++ b/src/api/controllers/address.ts
@@ -133,7 +133,7 @@ export async function getRelatedTransactionsCountByType(
   return await withCache(
     ['getRelatedTransactionsCountByType', arguments],
     () => stores[shardID].address.getRelatedTransactionsCountByType(address, type, filter),
-    30 * 1000
+    1000 * 5
   )
 }
 

--- a/src/api/controllers/log.ts
+++ b/src/api/controllers/log.ts
@@ -51,7 +51,7 @@ export async function getLogsByField(
   return await withCache(
     ['getLogsByField', arguments],
     () => stores[shardID].log.getLogsByField(field, value),
-    1000 * 10
+    1000
   )
 }
 

--- a/src/api/controllers/signature.ts
+++ b/src/api/controllers/signature.ts
@@ -21,6 +21,6 @@ export async function getSignaturesByHash(
   return await withCache(
     ['getSignaturesByHash', arguments],
     () => stores[0].signature.getSignaturesByHash(hash),
-    1000 * 10
+    1000
   )
 }

--- a/src/api/controllers/transaction.ts
+++ b/src/api/controllers/transaction.ts
@@ -37,7 +37,7 @@ export async function getTransactionByField(
   const txs = await withCache(
     ['getTransactionByField', arguments],
     () => stores[shardID].transaction.getTransactionsByField(field, value),
-    1000 * 10
+    1000
   )
 
   if (!txs!.length) {


### PR DESCRIPTION
Reduced cache lifetime for api endpoints getLogsByField, getSignaturesByHash, getTransactionByField