### PR TITLE
Add etherscan-compatible api controller; Implement eth_gasPrice method

### DIFF
--- a/src/api/controllers/rpcProxy.ts
+++ b/src/api/controllers/rpcProxy.ts
@@ -1,0 +1,19 @@
+// Etherscan-compatible api controller
+
+import {withCache} from 'src/api/controllers/cache'
+import {transport} from 'src/indexer/rpc/transport'
+
+export enum ProxyActions {
+  ethGasPrice = 'eth_gasPrice',
+}
+
+export async function getGasPrice() {
+  return await withCache(
+    ['getGasPrice', arguments],
+    async () => {
+      const data = await transport(0, 'hmy_gasPrice', [])
+      return data
+    },
+    1000 * 60
+  )
+}

--- a/src/api/rest/routes/api.ts
+++ b/src/api/rest/routes/api.ts
@@ -1,0 +1,43 @@
+import {NextFunction, Request, Response, Router} from 'express'
+import {catchAsync} from 'src/api/rest/utils'
+import {ProxyActions, getGasPrice} from 'src/api/controllers/rpcProxy'
+
+export const apiRouter = Router({mergeParams: true})
+
+apiRouter.get('/', catchAsync(getApi))
+
+const wrapSuccessfulResponse = (value: string) => {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: value,
+  }
+}
+
+const wrapErrorResponse = (message: string) => {
+  return {
+    status: 0,
+    result: message,
+  }
+}
+
+export async function getApi(req: Request, res: Response, next: NextFunction) {
+  const {module, action} = req.query
+
+  if (module === 'proxy') {
+    try {
+      switch (action) {
+        case ProxyActions.ethGasPrice: {
+          const data = await getGasPrice()
+          return res.send(wrapSuccessfulResponse(data))
+        }
+        default:
+          return res.send(wrapErrorResponse('Error! Missing Or invalid Action name'))
+      }
+    } catch (e) {
+      return res.send(wrapErrorResponse(e.message || 'Unknown error'))
+    }
+  }
+
+  res.send(wrapErrorResponse('Error! Missing Or invalid Module name'))
+}

--- a/src/api/rest/routes/api.ts
+++ b/src/api/rest/routes/api.ts
@@ -35,7 +35,9 @@ export async function getApi(req: Request, res: Response, next: NextFunction) {
           return res.send(wrapErrorResponse('Error! Missing Or invalid Action name'))
       }
     } catch (e) {
-      return res.send(wrapErrorResponse(e.message || 'Unknown error'))
+      return res.send(
+        wrapErrorResponse('Error! Cannot get proxy data, check service rpc configuration')
+      )
     }
   }
 

--- a/src/api/rest/server.ts
+++ b/src/api/rest/server.ts
@@ -26,6 +26,7 @@ import {rpcRouter} from 'src/api/rest/routes/rpcRouter'
 import {transport} from 'src/api/rest/transport'
 import prometheusRegister from 'src/api/prometheus'
 import {verifyApiKey} from 'src/api/middlewares/verifyApiKey'
+import {apiRouter} from 'src/api/rest/routes/api'
 const l = logger(module)
 
 export const RESTServer = async () => {
@@ -91,6 +92,7 @@ export const RESTServer = async () => {
     },
     transport
   )
+  api.use('/api', apiRouter, transport)
 
   let server: Server
 

--- a/src/types/blockchain.ts
+++ b/src/types/blockchain.ts
@@ -16,6 +16,7 @@ export type RPCHarmonyMethod =
   | 'hmyv2_getTransactionReceipt'
   | 'hmy_getBalance'
   | 'hmyv2_getTransactionsCount'
+  | 'hmy_gasPrice'
 
 export type ShardID = 0 | 1 | 2 | 3
 


### PR DESCRIPTION
Added eth_gasPrice method, example request:
```
<ApiUrl>/api?module=proxy&action=eth_gasPrice
```
Response:
```
{"jsonrpc":"2.0","id":1,"result":"0xe8d4a51000"}
```

Notes:
1) REST rate limiter affects `/api` route (if enabled in config)
2) Api key is disabled for `/api` route
3) Data is updated every minute