### PR TITLE
Metrics top

### DIFF
--- a/src/api/controllers/metrics.ts
+++ b/src/api/controllers/metrics.ts
@@ -43,17 +43,14 @@ export async function getMetricsByType(
   )
 }
 
-export async function getTopMetricsByType(
-  type: MetricsTopType,
-  daysCount = 1
-): Promise<any | null> {
+export async function getTopMetricsByType(type: MetricsTopType, period = 1): Promise<any | null> {
   validator({
     type: isOneOf(type, [...Object.values(MetricsDailyType)]),
-    daysCount: isLimit(daysCount, 1000),
+    period: isOneOf(period, [1, 3, 7]),
   })
   return await withCache(
     ['getTopMetricsByType', arguments],
-    () => stores[0].metrics.getTopMetricsByType(type, daysCount),
+    () => stores[0].metrics.getTopMetricsByType(type, period),
     1000 * 60 * 10
   )
 }

--- a/src/api/controllers/metrics.ts
+++ b/src/api/controllers/metrics.ts
@@ -39,13 +39,13 @@ export async function getMetricsByType(
   return await withCache(
     ['getMetricsByType', arguments],
     () => stores[0].metrics.getMetricsByType(type, offset, limit),
-    1000 * 60 * 60 * 1
+    1000 * 60 * 10
   )
 }
 
 export async function getTopMetricsByType(type: MetricsTopType, period = 1): Promise<any | null> {
   validator({
-    type: isOneOf(type, [...Object.values(MetricsDailyType)]),
+    type: isOneOf(type, [...Object.values(MetricsTopType)]),
     period: isOneOf(period, [1, 3, 7]),
   })
   return await withCache(

--- a/src/api/controllers/metrics.ts
+++ b/src/api/controllers/metrics.ts
@@ -1,8 +1,8 @@
 import {withCache} from 'src/api/controllers/cache'
 import {stores} from 'src/store'
-import {MetricsType} from 'src/types'
+import {MetricsDailyType, MetricsTopType} from 'src/types'
 import {validator} from 'src/utils/validators/validators'
-import {isAddress, isLimit, isOffset, isOneOf, isShard} from 'src/utils/validators'
+import {isLimit, isOffset, isOneOf} from 'src/utils/validators'
 
 const DefaultLimit = 14
 
@@ -27,12 +27,12 @@ export async function getWalletsCountLast14Days(limit = DefaultLimit): Promise<a
 }
 
 export async function getMetricsByType(
-  type: MetricsType,
+  type: MetricsDailyType,
   offset = 0,
   limit = DefaultLimit
 ): Promise<any | null> {
   validator({
-    type: isOneOf(type, [...Object.values(MetricsType)]),
+    type: isOneOf(type, [...Object.values(MetricsDailyType)]),
     offset: isOffset(offset),
     limit: isLimit(limit, 2000),
   })
@@ -40,5 +40,20 @@ export async function getMetricsByType(
     ['getMetricsByType', arguments],
     () => stores[0].metrics.getMetricsByType(type, offset, limit),
     1000 * 60 * 60 * 1
+  )
+}
+
+export async function getTopMetricsByType(
+  type: MetricsTopType,
+  daysCount = 1
+): Promise<any | null> {
+  validator({
+    type: isOneOf(type, [...Object.values(MetricsDailyType)]),
+    daysCount: isLimit(daysCount, 1000),
+  })
+  return await withCache(
+    ['getTopMetricsByType', arguments],
+    () => stores[0].metrics.getTopMetricsByType(type, daysCount),
+    1000 * 60 * 10
   )
 }

--- a/src/api/rest/routes/metrics.ts
+++ b/src/api/rest/routes/metrics.ts
@@ -1,7 +1,7 @@
 import {Response, Request, Router, NextFunction} from 'express'
 import * as controllers from 'src/api/controllers'
 import {catchAsync} from 'src/api/rest/utils'
-import {MetricsType} from 'src/types'
+import {MetricsDailyType} from 'src/types'
 
 export const metricsRouter = Router({mergeParams: true})
 
@@ -31,6 +31,10 @@ export async function getMetricsByType(req: Request, res: Response, next: NextFu
     offset: (+offset! as number) || 0,
     limit: (+limit! as number) || 14,
   }
-  const data = await controllers.getMetricsByType(type as MetricsType, filter.offset, filter.limit)
+  const data = await controllers.getMetricsByType(
+    type as MetricsDailyType,
+    filter.offset,
+    filter.limit
+  )
   next(data)
 }

--- a/src/indexer/indexer/metrics/stats.ts
+++ b/src/indexer/indexer/metrics/stats.ts
@@ -30,6 +30,17 @@ const runLoop = async () => {
   }
 }
 
+const updateTopDailyMetrics = async () => {
+  const periods = [1, 3, 7] // Top metrics for each 1, 3, 7 last days period
+  for (let i = 0; i < periods.length; i++) {
+    const period = periods[i]
+    await stores[0].metrics.updateTopOne(MetricsTopType.topOneSender, period)
+    await stores[0].metrics.updateTopOne(MetricsTopType.topOneReceiver, period)
+    await stores[0].metrics.updateTopTxsCount(MetricsTopType.topTxsCountSent, period)
+    await stores[0].metrics.updateTopTxsCount(MetricsTopType.topTxsCountReceived, period)
+  }
+}
+
 // const runDailyMetricsIndexer = async () => {
 //   try {
 //     const offset = 0 // manually set offset to continue interrupted migration
@@ -50,19 +61,3 @@ const runLoop = async () => {
 //     console.log('Error on metrics batch update', e)
 //   }
 // }
-
-const updateTopDailyMetrics = async () => {
-  try {
-    const periods = [1, 3, 7] // Top metrics for each 1, 3, 7 last days period
-    for (let i = 0; i < periods.length; i++) {
-      const period = periods[i]
-      const timeStart = Date.now()
-      await stores[0].metrics.updateTopOne(MetricsTopType.topOneSender, period)
-      await stores[0].metrics.updateTopOne(MetricsTopType.topOneReceiver, period)
-      console.log('Results :', period, Math.round((Date.now() - timeStart) / 1000), 's')
-    }
-    console.log('Stop top metrics')
-  } catch (e) {
-    console.log('Error on top metrics batch update', e)
-  }
-}

--- a/src/indexer/indexer/metrics/stats.ts
+++ b/src/indexer/indexer/metrics/stats.ts
@@ -1,5 +1,6 @@
 import {logger} from 'src/logger'
 import {stores} from 'src/store'
+import {MetricsTopType} from 'src/types'
 
 const l = logger(module)
 const interval = 1000 * 60 * 60 * 4
@@ -28,24 +29,25 @@ const runLoop = async () => {
   }
 }
 
-// const runMetricsIndexer = async () => {
-//   try {
-//     const offset = 0 // manually set offset if migration was interrupted
-//     const batchDays = 14
-//     for (let i = 0; i < 1000; i++) {
-//       const from = offset + i * batchDays + batchDays
-//       const to = offset + i * batchDays
-//       const timeStart = Date.now()
-//       console.log('Index metrics: i', i, 'from', from, 'to', to)
-//       const rows = await stores[0].metrics.updateWalletsCount(from, to)
-//       console.log('Rows', rows)
-//       console.log('Result:', rows.length, Math.round((Date.now() - timeStart) / 1000), 's')
-//       if (rows.length === 0) {
-//         break
-//       }
-//     }
-//     console.log('Stop metrics')
-//   } catch (e) {
-//     console.log('Error on metrics batch update', e)
-//   }
-// }
+const runMetricsIndexer = async () => {
+  try {
+    const offset = 0 // manually set offset to continue interrupted migration
+    const batchDays = 1
+    for (let i = 0; i < 14; i++) {
+      const from = offset + i * batchDays + batchDays
+      const to = offset + i * batchDays
+      const timeStart = Date.now()
+      console.log('Index metrics: i', i, 'from', from, 'to', to)
+      // const rows = await stores[0].metrics.updateWalletsCount(from, to)
+      const rows = await stores[0].metrics.updateTopOne(MetricsTopType.topOneSender, from, to)
+      await stores[0].metrics.updateTopOne(MetricsTopType.topOneReceiver, from, to)
+      console.log('Results count:', rows.length, Math.round((Date.now() - timeStart) / 1000), 's')
+      if (rows.length === 0) {
+        break
+      }
+    }
+    console.log('Stop metrics')
+  } catch (e) {
+    console.log('Error on metrics batch update', e)
+  }
+}

--- a/src/indexer/indexer/metrics/stats.ts
+++ b/src/indexer/indexer/metrics/stats.ts
@@ -7,8 +7,7 @@ const interval = 1000 * 60 * 60 * 4
 
 export const statsIndexer = () => {
   l.info('Metrics indexer starting...')
-  // runLoop()
-  updateTopDailyMetrics()
+  runLoop()
 }
 
 const runLoop = async () => {

--- a/src/indexer/indexer/metrics/stats.ts
+++ b/src/indexer/indexer/metrics/stats.ts
@@ -7,7 +7,8 @@ const interval = 1000 * 60 * 60 * 4
 
 export const statsIndexer = () => {
   l.info('Metrics indexer starting...')
-  runLoop()
+  // runLoop()
+  updateTopDailyMetrics()
 }
 
 const runLoop = async () => {
@@ -19,8 +20,8 @@ const runLoop = async () => {
       stores[0].metrics.updateTransactionsCount(limit),
       stores[0].metrics.updateAverageFee(limit),
       stores[0].metrics.updateBlockSize(limit),
-      // stores[0].metrics.updateTopContracts(),
     ])
+    await updateTopDailyMetrics()
     l.info(`Daily metrics updated in ${Math.round((Date.now() - dateStart) / 1000)}s`)
   } catch (e) {
     l.error('Error on metrics update:', e.message)
@@ -29,25 +30,39 @@ const runLoop = async () => {
   }
 }
 
-const runMetricsIndexer = async () => {
+// const runDailyMetricsIndexer = async () => {
+//   try {
+//     const offset = 0 // manually set offset to continue interrupted migration
+//     const batchDays = 1
+//     for (let i = 0; i < 14; i++) {
+//       const from = offset + i * batchDays + batchDays
+//       const to = offset + i * batchDays
+//       const timeStart = Date.now()
+//       console.log('Index metrics: i', i, 'from', from, 'to', to)
+//       const rows = await stores[0].metrics.updateWalletsCount(from, to)
+//       console.log('Results count:', rows.length, Math.round((Date.now() - timeStart) / 1000), 's')
+//       if (rows.length === 0) {
+//         break
+//       }
+//     }
+//     console.log('Stop metrics')
+//   } catch (e) {
+//     console.log('Error on metrics batch update', e)
+//   }
+// }
+
+const updateTopDailyMetrics = async () => {
   try {
-    const offset = 0 // manually set offset to continue interrupted migration
-    const batchDays = 1
-    for (let i = 0; i < 14; i++) {
-      const from = offset + i * batchDays + batchDays
-      const to = offset + i * batchDays
+    const periods = [1, 3, 7] // Top metrics for each 1, 3, 7 last days period
+    for (let i = 0; i < periods.length; i++) {
+      const period = periods[i]
       const timeStart = Date.now()
-      console.log('Index metrics: i', i, 'from', from, 'to', to)
-      // const rows = await stores[0].metrics.updateWalletsCount(from, to)
-      const rows = await stores[0].metrics.updateTopOne(MetricsTopType.topOneSender, from, to)
-      await stores[0].metrics.updateTopOne(MetricsTopType.topOneReceiver, from, to)
-      console.log('Results count:', rows.length, Math.round((Date.now() - timeStart) / 1000), 's')
-      if (rows.length === 0) {
-        break
-      }
+      await stores[0].metrics.updateTopOne(MetricsTopType.topOneSender, period)
+      await stores[0].metrics.updateTopOne(MetricsTopType.topOneReceiver, period)
+      console.log('Results :', period, Math.round((Date.now() - timeStart) / 1000), 's')
     }
-    console.log('Stop metrics')
+    console.log('Stop top metrics')
   } catch (e) {
-    console.log('Error on metrics batch update', e)
+    console.log('Error on top metrics batch update', e)
   }
 }

--- a/src/store/postgres/queryMapper.ts
+++ b/src/store/postgres/queryMapper.ts
@@ -40,6 +40,7 @@ export const mapNaming: Record<string, string> = {
   token_uri: 'tokenURI',
   extra_mark: 'extraMark',
   event_type: 'eventType',
+  updated_at: 'updatedAt',
 }
 
 export const mapNamingReverse: Record<string, string> = Object.keys(mapNaming).reduce((a, k) => {

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -478,3 +478,29 @@ create table if not exists metrics_daily
     created_at          timestamp default now(),
     unique (type, date)
 );
+
+do
+$$
+    begin
+        create type metrics_top_type as enum (
+            'top_one_sender',
+            'top_one_receiver',
+            'top_txs_count_sent',
+            'top_txs_count_received'
+            );
+    exception
+        when duplicate_object then null;
+    end
+$$;
+
+create table if not exists metrics_top
+(
+    id                  serial primary key,
+    type                metrics_top_type,
+    date                timestamp not null,
+    address             char(42) not null,
+    value               numeric,
+    share               numeric  default (0),
+    created_at          timestamp default now(),
+    unique (type, date, address)
+);

--- a/src/store/postgres/sql/scheme.sql
+++ b/src/store/postgres/sql/scheme.sql
@@ -495,12 +495,12 @@ $$;
 
 create table if not exists metrics_top
 (
-    id                  serial primary key,
     type                metrics_top_type,
-    date                timestamp not null,
+    period              smallint not null,
     address             char(42) not null,
     value               numeric,
-    share               numeric  default (0),
-    created_at          timestamp default now(),
-    unique (type, date, address)
+    rank                smallint not null,
+    share               real default (0),
+    updated_at          timestamp default now(),
+    unique (type, period, address)
 );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -68,9 +68,16 @@ export interface EthGetLogFilter {
   blockhash?: string
 }
 
-export enum MetricsType {
+export enum MetricsDailyType {
   walletsCount = 'wallets_count',
   transactionsCount = 'transactions_count',
   averageFee = 'average_fee',
   blockSize = 'block_size',
+}
+
+export enum MetricsTopType {
+  topOneSender = 'top_one_sender',
+  topOneReceiver = 'top_one_receiver',
+  topTxsCountSent = 'top_txs_count_sent',
+  topTxsCountReceived = 'top_txs_count_received',
 }


### PR DESCRIPTION
Added top metrics indexer
Each top metrics type has a period: 1, 3 or 7 last days, including current day

Schema update:
```
 create type metrics_top_type as enum (
   'top_one_sender',
   'top_one_receiver',
   'top_txs_count_sent',
   'top_txs_count_received'
 );

create table if not exists metrics_top
(
    type                metrics_top_type,
    period              smallint not null,
    address             char(42) not null,
    value               numeric,
    rank                smallint not null,
    share               real default (0),
    updated_at          timestamp default now(),
    unique (type, period, address)
);
```